### PR TITLE
Reinstate frame gating for voxel clearing

### DIFF
--- a/shaders/program/prepare_frame.csh
+++ b/shaders/program/prepare_frame.csh
@@ -50,7 +50,8 @@ void main() {
 
     // Only clear buffers right after starting the path tracer (F1 pressed)
     renderState.clear = (renderState.frame <= 1);
-    {
+
+    if (renderState.frame <= 1) {
         quadBuffer.aabb = scene_aabb(10000, 10000, 10000, -10000, -10000, -10000);
         quadBuffer.count = 0u;
 


### PR DESCRIPTION
## Summary
- keep voxel buffer clearing and voxelization limited to the first frame when the tracer starts
- restore conditional reset block in `prepare_frame.csh`

## Testing
- `glslangValidator -V -S geom shaders/program/voxelization/shadow.gsh` *(fails: `#include` directives not supported)*

------
https://chatgpt.com/codex/tasks/task_e_688974a1eb9083308a31b9158bd04e70