### PR TITLE
Fix initial performance drop

### DIFF
--- a/shaders/program/camera/exposure/histogram.csh
+++ b/shaders/program/camera/exposure/histogram.csh
@@ -28,6 +28,10 @@ void main() {
     histogramShared[gl_LocalInvocationIndex] = 0u;
     barrier();
 
+    if (renderState.frame == 0) {
+        return;
+    }
+
     uvec2 dim = uvec2(viewWidth, viewHeight);
     if (gl_GlobalInvocationID.x < dim.x && gl_GlobalInvocationID.y < dim.y) {
         vec3 color = getFilmAverageColor(ivec2(gl_GlobalInvocationID.xy));


### PR DESCRIPTION
## Summary
- avoid running heavy histogram calculation when frame counter is 0

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6889b2caaef88330bd6fbc42c5a093c7